### PR TITLE
Fix overflow on filling ID

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: mlugg/setup-zig@v2
         with:
-          version: master
+          version: 0.15.1
 
       - name: Run zig fmt
         if: matrix.os == 'Linux'

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .mcl,
     .version = "0.7.0",
     .fingerprint = 0xb59a9476469c376d,
-    .minimum_zig_version = "0.15.0-dev.1411+163e9ce7d",
+    .minimum_zig_version = "0.15.1",
     .dependencies = .{
         .mdfunc = .{
             .url = "https://github.com/pmotionf/mdfunc.zig/archive/52d8d69.tar.gz",

--- a/src/Line.zig
+++ b/src/Line.zig
@@ -43,7 +43,7 @@ pub fn init(
     config: Config.Line,
 ) !void {
     result.index = line_index;
-    result.id = line_index + 1;
+    result.id = @as(Id, line_index) + 1;
     result.connection = try allocator.alloc(Range, config.ranges.len);
     errdefer allocator.free(result.connection);
     result.axes = try allocator.alloc(Axis, config.axes);

--- a/src/registers.zig
+++ b/src/registers.zig
@@ -99,8 +99,7 @@ pub fn nestedWrite(
 test nestedWrite {
     const example_x: X = .{};
     var result_buffer: [2048]u8 = undefined;
-    var buf = std.io.fixedBufferStream(&result_buffer);
-    const buf_writer = buf.writer();
+    var writer: std.Io.Writer = .fixed(&result_buffer);
     try std.testing.expectEqualStrings(
         \\hall_alarm: {
         \\    axis1: {
@@ -122,7 +121,7 @@ test nestedWrite {
             "hall_alarm",
             example_x.hall_alarm,
             0,
-            buf_writer,
+            &writer,
         )],
     );
 }


### PR DESCRIPTION
Testing the mock mcl with the maximum 256 lines, this integer overflow pops up.

I use this opportunity to lock the zig version to 0.15.1 as well.