### PR TITLE
Reorder `control_kind` bit

### DIFF
--- a/src/registers/ww.zig
+++ b/src/registers/ww.zig
@@ -9,10 +9,10 @@ pub const Ww = packed struct(u256) {
     carrier: packed struct(u80) {
         target: f32 = 0.0,
         id: u10 = 0,
-        control_kind: ControlKind = .none,
         disable_cas: bool = false,
         isolate_link_prev_axis: bool = false,
         isolate_link_next_axis: bool = false,
+        control_kind: ControlKind = .none,
         _: u1 = 0,
         velocity: u16 = 0,
         acceleration: u16 = 0,


### PR DESCRIPTION
In the latest commit, the `control_kind` bit in ww is reordered. I do not know if this is accidental or not, but it makes the server broken. If the `control_kind` bit is intended to be re-ordered and the changes is implemented to the cc-link, just close this PR. However, if the re-order is accidental, this PR can be used to fix that issue.